### PR TITLE
feat(Apollo): make use of generic type on MutationOptions in Apollo#mutate

### DIFF
--- a/src/Apollo.ts
+++ b/src/Apollo.ts
@@ -6,7 +6,6 @@ import {
   WatchQueryOptions,
   MutationOptions,
   SubscriptionOptions,
-  ApolloExecutionResult,
 } from 'apollo-client';
 import { Observable } from 'rxjs/Observable';
 import { from } from 'rxjs/observable/from';
@@ -35,10 +34,8 @@ export class ApolloBase {
     );
   }
 
-  public mutate<T>(options: MutationOptions): Observable<ApolloExecutionResult<T>> {
-    return wrapWithZone<ApolloExecutionResult<T>>(
-      fromPromise<ApolloExecutionResult<T>>(() => this.client.mutate<T>(options)),
-    );
+  public mutate<T>(options: MutationOptions<T>) {
+    return wrapWithZone(fromPromise(() => this.client.mutate(options)));
   }
 
   public subscribe(options: SubscriptionOptions): Observable<any> {


### PR DESCRIPTION
Without this the `MutationOptions` generic takes the default type of `{ [key: string]: any; }` which isn't very useful. This is needed by the `updateQueries` option to detect the right type for the `mutationResult` data object.