### PR TITLE
Use `InjectionToken`, instead of deprecated `OpaqueToken`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- Use `InjectionToken`, instead of deprecated `OpaqueToken` ([PR #358](https://github.com/apollographql/apollo-angular/pull/358))
+
 ### v0.13.1
 
 - Update dependencies ([PR #347](https://github.com/apollographql/apollo-angular/pull/304))

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "deploy": "./scripts/deploy.sh"
   },
   "peerDependencies": {
-    "@angular/core": "^2.0.0 || >=4.0.0-beta <5.0.0",
-    "apollo-client": ">=0.8.0 <=0.10.1 || >=1.0.0-rc <2.0.0 || ^1.9.0 || ^1.8.0",
-    "rxjs": "^5.0.0-beta.12 || ^5.0.0-rc.1 || ^5.0.0 || ^5.4.2"
+    "@angular/core": ">=4.0.0 <5.0.0",
+    "apollo-client": ">=1.0.0 <2.0.0",
+    "rxjs": "^5.0.1"
   },
   "dependencies": {
     "apollo-client-rxjs": "^0.6.0-rc.1"

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,4 +1,6 @@
-import { OpaqueToken } from '@angular/core';
+import { InjectionToken } from '@angular/core';
 
-export const CLIENT_MAP_WRAPPER = new OpaqueToken('apollo/client-map-wrapper');
-export const CLIENT_MAP = new OpaqueToken('apollo/client-map');
+import { ClientMapWrapper, ClientMap } from './types';
+
+export const CLIENT_MAP_WRAPPER = new InjectionToken<ClientMapWrapper>('apollo/client-map-wrapper');
+export const CLIENT_MAP = new InjectionToken<ClientMap>('apollo/client-map');


### PR DESCRIPTION
Previously #316