### PR TITLE
chore(build): add support for npm5 git installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "postbuild": "npm run bundle",
     "bundle": "rollup -c",
     "clean": "rimraf build/* coverage/*",
-    "prepublish": "npm run clean && npm run build",
+    "prepare": "npm run build",
     "commitmsg": "commitlint -e",
     "deploy": "./scripts/deploy.sh"
   },


### PR DESCRIPTION
Clean was already run on prebuild and I've replaced prepublish with prepare to add support for installing via git as was introduced in npm5

From any project you can do: `npm i github:intellix/apollo-angular#npm5-scripts`