### PR TITLE
test(core): setVariables is covered by tests

### DIFF
--- a/packages/apollo-angular/tests/QueryRef.spec.ts
+++ b/packages/apollo-angular/tests/QueryRef.spec.ts
@@ -257,14 +257,14 @@ describe('QueryRef', () => {
 
   test('should be able to call setVariables()', () => {
     const mockCallback = jest.fn();
-    const opts = {};
-    obsQuery.setOptions = mockCallback.mockReturnValue('expected');
+    const variables = {};
+    obsQuery.setVariables = mockCallback.mockReturnValue('expected');
 
-    const result = queryRef.setOptions(opts);
+    const result = queryRef.setVariables(variables);
 
     expect(result).toBe('expected');
     expect(mockCallback.mock.calls.length).toBe(1);
-    expect(mockCallback.mock.calls[0][0]).toBe(opts);
+    expect(mockCallback.mock.calls[0][0]).toBe(variables);
   });
 
   test('should handle multiple subscribers', done => {


### PR DESCRIPTION
Tests for `setVariables` was an incorrect copy/paste from `setOptions`.