### PR TITLE
GraphQL directive

### DIFF
--- a/packages/apollo-angular/src/ApolloModule.ts
+++ b/packages/apollo-angular/src/ApolloModule.ts
@@ -2,9 +2,10 @@ import {NgModule} from '@angular/core';
 
 import {Apollo} from './Apollo';
 import {SelectPipe} from './SelectPipe';
+import {GraphqlDirective} from './GraphqlDirective';
 
 export const PROVIDERS = [Apollo];
-export const DECLARATIONS = [SelectPipe];
+export const DECLARATIONS = [SelectPipe, GraphqlDirective];
 
 @NgModule({
   providers: PROVIDERS,

--- a/packages/apollo-angular/src/GraphqlDirective.ts
+++ b/packages/apollo-angular/src/GraphqlDirective.ts
@@ -9,23 +9,31 @@ import {
 } from '@angular/core';
 import {Subject} from 'rxjs';
 import {takeUntil, debounceTime} from 'rxjs/operators';
+import {ApolloQueryResult} from 'apollo-client';
 
 import {Query} from './Query';
 import {QueryRef} from './QueryRef';
 
+export interface GraphqlContext<T> {
+  query: QueryRef<T>;
+  result: ApolloQueryResult<T>;
+  loading: boolean;
+  data: T;
+}
+
 @Directive({
   selector: '[graphql]',
 })
-export class GraphqlDirective implements OnInit, OnDestroy, OnChanges {
-  @Input() public graphql: Query;
+export class GraphqlDirective<T> implements OnInit, OnDestroy, OnChanges {
+  @Input() public graphql: Query<T>;
   @Input() public variables: Record<any, string>;
   @Input() public debounce: number = 0;
 
   private ngDestroy: Subject<void>;
-  private ref: QueryRef<any>;
+  private ref: QueryRef<T>;
 
   constructor(
-    private tRef: TemplateRef<any>,
+    private tRef: TemplateRef<GraphqlContext<T>>,
     private vcRef: ViewContainerRef,
   ) {}
 

--- a/packages/apollo-angular/src/GraphqlDirective.ts
+++ b/packages/apollo-angular/src/GraphqlDirective.ts
@@ -1,0 +1,68 @@
+import {
+  Directive,
+  TemplateRef,
+  ViewContainerRef,
+  Input,
+  OnInit,
+  OnDestroy,
+  OnChanges,
+} from '@angular/core';
+import {Subject} from 'rxjs';
+import {takeUntil, debounceTime} from 'rxjs/operators';
+
+import {Query} from './Query';
+import {QueryRef} from './QueryRef';
+
+@Directive({
+  selector: '[graphql]',
+})
+export class GraphqlDirective implements OnInit, OnDestroy, OnChanges {
+  @Input() public graphql: Query;
+  @Input() public variables: Record<any, string>;
+  @Input() public debounce: number = 0;
+
+  private ngDestroy: Subject<void>;
+  private ref: QueryRef<any>;
+
+  constructor(
+    private tRef: TemplateRef<any>,
+    private vcRef: ViewContainerRef,
+  ) {}
+
+  public ngOnInit() {
+    this.ngDestroy = new Subject<void>();
+    this.ref = this.graphql.query(this.variables);
+
+    this.createView({
+      loading: true,
+    });
+
+    this.ref.valueChanges
+      .pipe(takeUntil(this.ngDestroy), debounceTime(this.debounce))
+      .subscribe(result => this.updateView(result));
+  }
+
+  public ngOnChanges() {
+    // TODO: handle that
+  }
+
+  private createView(result: any) {
+    this.vcRef.createEmbeddedView(this.tRef, {
+      query: this.ref,
+      loading: result.loading,
+      data: result.data,
+      result,
+    });
+  }
+
+  private updateView(result: any) {
+    this.createView(result);
+  }
+
+  public ngOnDestroy() {
+    if (this.ngDestroy) {
+      this.ngDestroy.next();
+      this.ngDestroy.complete();
+    }
+  }
+}

--- a/packages/apollo-angular/src/GraphqlDirective.ts
+++ b/packages/apollo-angular/src/GraphqlDirective.ts
@@ -6,19 +6,42 @@ import {
   OnInit,
   OnDestroy,
   OnChanges,
+  SimpleChanges,
 } from '@angular/core';
 import {Subject} from 'rxjs';
 import {takeUntil, debounceTime} from 'rxjs/operators';
-import {ApolloQueryResult} from 'apollo-client';
+import {
+  ApolloQueryResult,
+  FetchPolicy,
+  ErrorPolicy,
+  NetworkStatus,
+  ApolloError,
+} from 'apollo-client';
 
 import {Query} from './Query';
 import {QueryRef} from './QueryRef';
 
-export interface GraphqlContext<T> {
-  query: QueryRef<T>;
+export interface GraphqlContext<T, V = Record<string, any>> {
+  query: QueryRef<T, V>;
   result: ApolloQueryResult<T>;
   loading: boolean;
+  networkStatus: NetworkStatus;
+  errors: ApolloError;
   data: T;
+  load: () => void;
+}
+
+function compact(obj: any) {
+  return Object.keys(obj).reduce(
+    (acc, key) => {
+      if (obj[key] !== undefined) {
+        acc[key] = obj[key];
+      }
+
+      return acc;
+    },
+    {} as any,
+  );
 }
 
 @Directive({
@@ -26,7 +49,13 @@ export interface GraphqlContext<T> {
 })
 export class GraphqlDirective<T> implements OnInit, OnDestroy, OnChanges {
   @Input() public graphql: Query<T>;
-  @Input() public variables: Record<any, string>;
+  @Input() public variables?: Record<any, string>;
+  @Input() public pollInterval?: number;
+  @Input() public notifyOnNetworkStatusChange?: number;
+  @Input() public fetchPolicy?: FetchPolicy;
+  @Input() public errorPolicy?: ErrorPolicy;
+  @Input() public displayName?: string;
+  @Input() public context?: Record<string, any> = {};
   @Input() public debounce: number = 0;
 
   private ngDestroy: Subject<void>;
@@ -39,32 +68,76 @@ export class GraphqlDirective<T> implements OnInit, OnDestroy, OnChanges {
 
   public ngOnInit() {
     this.ngDestroy = new Subject<void>();
-    this.ref = this.graphql.query(this.variables);
+    this.initQuery();
+  }
+
+  public ngOnChanges(changes: SimpleChanges) {
+    if ('graphql' in changes) {
+      const {graphql} = changes;
+
+      if (
+        graphql.isFirstChange() ||
+        typeof graphql.previousValue !== 'function'
+      ) {
+        return;
+      }
+
+      this.ngDestroy.next();
+      this.initQuery();
+    }
+  }
+
+  private initQuery() {
+    this.ref = this.graphql.query(this.variables, this.createOptions());
 
     this.createView({
       loading: true,
-    });
+    } as any);
 
     this.ref.valueChanges
       .pipe(takeUntil(this.ngDestroy), debounceTime(this.debounce))
-      .subscribe(result => this.updateView(result));
+      .subscribe(result => this.handleResult(result));
   }
 
-  public ngOnChanges() {
-    // TODO: handle that
+  private handleResult(result: ApolloQueryResult<T>) {
+    this.updateView(result);
   }
 
   private createView(result: any) {
     this.vcRef.createEmbeddedView(this.tRef, {
       query: this.ref,
       loading: result.loading,
+      errors:
+        result.errors && result.errors.length > 0
+          ? new ApolloError({graphQLErrors: result.errors})
+          : null,
       data: result.data,
+      networkStatus: result.networkStatus,
       result,
     });
   }
 
-  private updateView(result: any) {
+  private updateView(result: ApolloQueryResult<T>) {
     this.createView(result);
+  }
+
+  private createOptions() {
+    return compact({
+      pollInterval: this.pollInterval,
+      fetchPolicy: this.fetchPolicy,
+      errorPolicy: this.errorPolicy,
+      notifyOnNetworkStatusChange: this.notifyOnNetworkStatusChange,
+      metadata: {
+        // TODO: make the structure of a component framework agnostic
+        component: {
+          displayName: this.displayName,
+        },
+        reactComponent: {
+          displayName: this.displayName,
+        },
+      },
+      context: this.context,
+    });
   }
 
   public ngOnDestroy() {

--- a/packages/apollo-angular/src/Query.ts
+++ b/packages/apollo-angular/src/Query.ts
@@ -1,0 +1,21 @@
+import {Injectable} from '@angular/core';
+import {DocumentNode} from 'graphql';
+
+import {Apollo} from './Apollo';
+import {QueryRef} from './QueryRef';
+import {QueryOptions} from './types';
+
+@Injectable()
+export class Query<T = {}, V = Record<string, any>> {
+  public readonly document: DocumentNode;
+
+  constructor(protected apollo: Apollo) {}
+
+  public query(variables?: V, options?: QueryOptions): QueryRef<T, V> {
+    return this.apollo.watchQuery<T, V>({
+      ...options,
+      variables,
+      query: this.document,
+    });
+  }
+}

--- a/packages/apollo-angular/src/api.ts
+++ b/packages/apollo-angular/src/api.ts
@@ -1,5 +1,6 @@
 export {Apollo, ApolloBase} from './Apollo';
 export {QueryRef} from './QueryRef';
+export {Query} from './Query';
 export {SelectPipe} from './SelectPipe';
 export {ApolloModule} from './ApolloModule';
 export {APOLLO_OPTIONS} from './tokens';

--- a/packages/apollo-angular/src/types.ts
+++ b/packages/apollo-angular/src/types.ts
@@ -1,3 +1,5 @@
+import {WatchQueryOptions} from 'apollo-client';
+
 export type R = Record<string, any>;
 
 export type TypedVariables<T> = {
@@ -7,3 +9,12 @@ export type TypedVariables<T> = {
 export interface ExtraSubscriptionOptions {
   useZone?: boolean;
 }
+
+export type StringLiteralDiff<T extends string, U extends string> = ({
+  [P in T]: P
+} &
+  {[P in U]: never} & {[x: string]: never})[T];
+export type Omit<T, K extends keyof T> = Pick<T, StringLiteralDiff<keyof T, K>>;
+
+export interface QueryOptions
+  extends Omit<WatchQueryOptions, 'query' | 'variables'> {}

--- a/packages/apollo-angular/tests/Query.spec.ts
+++ b/packages/apollo-angular/tests/Query.spec.ts
@@ -1,0 +1,94 @@
+import {setupAngular} from './_setup';
+
+import {Injectable} from '@angular/core';
+import {TestBed, inject} from '@angular/core/testing';
+import gql from 'graphql-tag';
+
+import {Query, Apollo} from '../src';
+
+const query = gql`
+  query heroes {
+    allHeroes {
+      name
+    }
+  }
+`;
+
+@Injectable()
+export class HeroesQuery extends Query {
+  public document = query;
+}
+
+describe('Query', () => {
+  let apolloMock: Apollo & {watchQuery: jest.Mock};
+  let heroesQuery: HeroesQuery;
+
+  function createApollo() {
+    apolloMock = {
+      watchQuery: jest.fn(),
+    } as any;
+
+    return apolloMock;
+  }
+
+  beforeAll(() => setupAngular());
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: Apollo,
+          useFactory: createApollo,
+        },
+        HeroesQuery,
+      ],
+    });
+  });
+
+  beforeEach(
+    inject([HeroesQuery], (_heroesQuery: HeroesQuery) => {
+      heroesQuery = _heroesQuery;
+    }),
+  );
+
+  test('should have document defined', () => {
+    expect(heroesQuery.document).toEqual(query);
+  });
+
+  test('should use watchQuery under the hood', () => {
+    apolloMock.watchQuery.mockReturnValue('QueryRef');
+
+    const result = heroesQuery.query();
+
+    expect(apolloMock.watchQuery).toBeCalled();
+    expect(result).toEqual('QueryRef');
+  });
+
+  test('should pass variables to Apollo.watchQuery', () => {
+    heroesQuery.query({foo: 1});
+
+    expect(apolloMock.watchQuery).toBeCalled();
+    expect(apolloMock.watchQuery.mock.calls[0][0]).toMatchObject({
+      variables: {foo: 1},
+    });
+  });
+
+  test('should pass options to Apollo.watchQuery', () => {
+    heroesQuery.query({}, {fetchPolicy: 'network-only'});
+
+    expect(apolloMock.watchQuery).toBeCalled();
+    expect(apolloMock.watchQuery.mock.calls[0][0]).toMatchObject({
+      fetchPolicy: 'network-only',
+    });
+  });
+
+  test('should not overwrite query when options object is provided', () => {
+    heroesQuery.query({}, {query: 'asd', fetchPolicy: 'cache-first'} as any);
+
+    expect(apolloMock.watchQuery).toBeCalled();
+    expect(apolloMock.watchQuery.mock.calls[0][0]).toMatchObject({
+      query,
+      fetchPolicy: 'cache-first',
+    });
+  });
+});


### PR DESCRIPTION
Extends #622 

**Purpose:**

Instead of keep repeating the same logic, I mean, subscribing to an observable to get the `loading`, `data` or a `networkStatus` to use them in a template, we could make it a bit easier.

**Usage:**

```ts
@Component({
  selector: 'app-list',
  template: `
    <ng-template [graphql]="postsQuery" let-loading="loading" let-data="data">
      
      <ul *ngIf="!loading">
        <li *ngFor="let post of data.posts">
          {{post.title}} by {{post.author.firstName}} {{post.author.lastName}}
          ({{post.votes}} votes)
        </li>
      </ul>

    </ng-template>
  `
})
export class ListComponent {
  // part of PR #622
  constructor(public postsQuery: PostsQuery) {}
}
```

```ts
@Component({
  selector: 'app-list',
  template: `
    <div *graphql="postsQuery" let-loading="loading" let-data="data">
      
      <ul *ngIf="!loading">
        <li *ngFor="let post of data.posts">
          {{post.title}} by {{post.author.firstName}} {{post.author.lastName}}
          ({{post.votes}} votes)
        </li>
      </ul>

    </div>
  `
})
export class ListComponent {
  // part of PR #622
  constructor(public postsQuery: PostsQuery) {}
}
```

**Example on stackblitz.io**
https://stackblitz.com/edit/apollo-angular-token-service-directive?file=app%2Flist.component.ts

**TODO:**

- [ ] figure out how to use variables (maybe `queryRef.setVariables({...})`)