### PR TITLE
Update auth docs to fix undefined headers param in setContext()

### DIFF
--- a/docs/source/recipes/authentication.md
+++ b/docs/source/recipes/authentication.md
@@ -56,7 +56,7 @@ class AppModule {
   ) {
     const http = httpLink.create({uri: '/graphql'});
 
-    const auth = setContext((_, { headers }) => {
+    const auth = setContext((request, previousContext) => {
       // get the authentication token from local storage if it exists
       const token = localStorage.getItem('token');
       // return the headers to the context so httpLink can read them
@@ -66,7 +66,9 @@ class AppModule {
         return {};
       } else {
         return {
-          headers: headers.append('Authorization', `Bearer ${token}`)
+          headers: {
+            Authorization: `JWT ${token}`
+          }
         };
       }
     });


### PR DESCRIPTION
The documentation for JWT authentication is outdated. This PR fixes it.

Check these out for references:
* https://github.com/apollographql/apollo-angular/issues/493
* https://github.com/apollographql/apollo-angular/tree/master/packages/apollo-angular-link-headers
