### PR TITLE
docs: Update blog URLs to reference blog.apollographql.com.

### DIFF
--- a/docs/source/features/developer-tooling.md
+++ b/docs/source/features/developer-tooling.md
@@ -21,7 +21,7 @@ Make requests against either your app’s GraphQL server or the Apollo Client ca
 
 ![Store Inspector](../assets/devtools/apollo-client-devtools/apollo-devtools-store.png)
 
-View the state of your client-side cache as a tree and inspect every object inside. Visualize the [mental model](https://dev-blog.apollodata.com/the-concepts-of-graphql-bc68bd819be3) of the Apollo cache. Search for specific keys and values in the store and see the path to those keys highlighted.
+View the state of your client-side cache as a tree and inspect every object inside. Visualize the [mental model](https://blog.apollographql.com/the-concepts-of-graphql-bc68bd819be3) of the Apollo cache. Search for specific keys and values in the store and see the path to those keys highlighted.
 
 ![Watched Query Inspector](../assets/devtools/apollo-client-devtools/apollo-devtools-queries.png)
 

--- a/packages/apollo-angular-link-persisted/README.md
+++ b/packages/apollo-angular-link-persisted/README.md
@@ -7,7 +7,7 @@
 
 An Apollo Link that allows to use Automatic Persisted Queries with `apollo-angular-link-http`.
 
-Read more about [Automatic Persisted Queries](https://dev-blog.apollodata.com/improve-graphql-performance-with-automatic-persisted-queries-c31d27b8e6ea).
+Read more about [Automatic Persisted Queries](https://blog.apollographql.com/improve-graphql-performance-with-automatic-persisted-queries-c31d27b8e6ea).
 
 ## How it works
 


### PR DESCRIPTION
This updates all blog URLs in the documentation to use blog.apollographql.com
as the domain, rather than dev-blog.apollodata.com.