### PR TITLE
build: change peerDependencies

### DIFF
--- a/packages/apollo-angular/CHANGELOG.md
+++ b/packages/apollo-angular/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Expose `queryId` in `QueryRef` [PR #733](https://github.com/apollographql/apollo-angular/pull/733)
 - Introduce `Query`, `Mutation`, `Subscription` services [PR #622](https://github.com/apollographql/apollo-angular/pull/622)
+- Angular 6.1 is now required (because of TypeScript 2.8)
+- TypeScript 2.8 is now required (because of Omit type)
+- Apollo Client ^2.3.4 is now required (versions before are not compatible because of the change in apollo-client)
 
 ### v1.1.2
 

--- a/packages/apollo-angular/package.json
+++ b/packages/apollo-angular/package.json
@@ -30,8 +30,8 @@
     "deploy": "../../scripts/deploy.sh ./scripts/testing.sh"
   },
   "peerDependencies": {
-    "@angular/core": "^6.0.0",
-    "apollo-client": "^2.0.0",
+    "@angular/core": "^6.1.0",
+    "apollo-client": "^2.3.4",
     "apollo-link": "^1.0.0",
     "rxjs": "^6.0.0",
     "zone.js": "~0.8.20"


### PR DESCRIPTION
Why TypeScript 2.8? I couldn't find an `Omit` type that would be compatible with 2.7 and 2.8+ versions. TS 2.8 brings `Exclude` type that is really helpful here. `Pick` + `Exclude` = `Omit`

Why we need `Omit` type?

In `Query` service we want to let user to use regular options (`WatchQueryOptions`) but without `query` and `variables` props because they both are defined already. Without `Omit` those properties would be required by TypeScript.