### PR TITLE
Fix typo in docs index page for Apollo Angular

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -44,7 +44,7 @@ If you have a favorite Angular tool, and something in Apollo makes it difficult 
 
 <h3 id="graphql-servers">GraphQL servers</h3>
 
-We believe that using GraphQL should be easy and fun. One of the ways Apollo is designed for this is that if you can write you query in GraphiQL, it'll work with Apollo Client! Because it doesn't assume anything beyond the official GraphQL specification, Apollo works with every GraphQL server implementation, for *every* language. It doesn't impose any requirements on your schema either! If you can send a query to a standard GraphQL server, Apollo can handle it. You can find a list of GraphQL server implementations on [graphql.org](http://graphql.org/code/#server-libraries).
+We believe that using GraphQL should be easy and fun. One of the ways Apollo is designed for this is that if you can write your query in GraphiQL, it'll work with Apollo Client! Because it doesn't assume anything beyond the official GraphQL specification, Apollo works with every GraphQL server implementation, for *every* language. It doesn't impose any requirements on your schema either! If you can send a query to a standard GraphQL server, Apollo can handle it. You can find a list of GraphQL server implementations on [graphql.org](http://graphql.org/code/#server-libraries).
 
 <h3 id="other-platforms" title="Other JS + native platforms">Other JavaScript + native platforms</h3>
 


### PR DESCRIPTION
There was a typo on the index page, and this pull request fixes it.

The change: `if you can write you query in GraphiQL` to `if you can write your query in GraphiQL`

It's a very small fix, but it's never good to have typos on landing pages, so I thought I'd go ahead and contribute a fix. :slightly_smiling_face: 
