### PR TITLE
update cache when using Query service

### DIFF
--- a/docs/source/features/caching.md
+++ b/docs/source/features/caching.md
@@ -60,12 +60,18 @@ class AppComponent {
       update: (proxy, { data: { createTodo } }) => {
         // Read the data from our cache for this query.
         const data = proxy.readQuery({ query: TodoAppQuery });
+        
+        // If you are using the Query service (TodoAppGQL) instead of defining your GQL as a constant, you can reference the query as:
+        // const data = proxy.readQuery({ query: this.todoAppGQL.document });
 
         // Add our todo from the mutation to the end.
         data.todos.push(createTodo);
 
         // Write our data back to the cache.
         proxy.writeQuery({ query: TodoAppQuery, data });
+        
+        // alternatively when using Query service:
+        // proxy.writeQuery({ query: this.todoAppGQL.document, data });
       },
     }).subscribe();
   }


### PR DESCRIPTION
I was using the Query service (https://www.apollographql.com/docs/angular/basics/services.html#Basic-example) as described in the article, and I figured out how to use it in the cache update. The query service seemed to be the way to go when you follow the guides in a linear fashion, so I wanted to share how to present the query in the proxy object.