### PR TITLE
Remove custom templates since we're disabling Apollo Bot

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md.md
@@ -1,9 +1,4 @@
-<!--
-  Thanks for filing a pull request on Apollo Client!
 
-  Please look at the following checklist to ensure that your PR
-  can be accepted quickly:
--->
 
 TODO:
 


### PR DESCRIPTION
Getting rid of this repos custom issue/PR templates (since we're no longer using Apollo Bot).