### PR TITLE
Revert "Update dependency hexo-renderer-less to v1 (#1038)"

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
     "hexo-browsersync": "0.3.0",
     "hexo-prism-plus": "1.1.0",
     "hexo-renderer-ejs": "0.3.1",
-    "hexo-renderer-less": "1.0.0",
+    "hexo-renderer-less": "0.2.0",
     "hexo-renderer-marked": "0.3.2",
     "hexo-server": "0.3.3",
     "meteor-theme-hexo": "2.0.1"


### PR DESCRIPTION
`hexo-renderer-less` v1 has some issues, and unfortunately breaks the docs. We'll roll it back for now (and update renovate to stop suggesting the `hexo-renderer-less` update).