### PR TITLE
Bugfix for Issue #1096

### DIFF
--- a/packages/apollo-angular-link-http-common/src/utils.ts
+++ b/packages/apollo-angular-link-http-common/src/utils.ts
@@ -31,13 +31,13 @@ export const fetch = (
         body: req.body,
       };
     } else {
-      Object.keys(req.body).forEach(param => {
-        if (shouldStringify(param.toLowerCase())) {
-          (req.body as any)[param] = JSON.stringify((req.body as any)[param]);
-        }
-      });
+      const params = Object.keys(req.body).reduce((obj: any, param) => {
+        const value = (req.body as any)[param];
+        obj[param] = shouldStringify(param) ? JSON.stringify(value) : value;
+        return obj;
+      }, {});
 
-      bodyOrParams = {params: req.body};
+      bodyOrParams = {params: params};
     }
   }
 


### PR DESCRIPTION
Fixes issue #1096 

Angular CLI was removing code when running production optimisations.  I don't have a satisfactory explanation into why other than simply a bug hidden somewhere in Angular CLI / Webpack / Uglify.  This code change seems to trick it into knowing that the code is necessary.