### PR TITLE
docs: use arrow function in useFactory

### DIFF
--- a/docs/source/basics/local-state.md
+++ b/docs/source/basics/local-state.md
@@ -25,7 +25,7 @@ import { defaults, resolvers } from './resolvers';
   // ...
   providers: [{
     provide: APOLLO_OPTIONS,
-    useFactory(httpLink: HttpLink) {
+    useFactory: (httpLink: HttpLink) => {
       const cache = new InMemoryCache();
 
       const http = httpLink.create({

--- a/docs/source/basics/setup.md
+++ b/docs/source/basics/setup.md
@@ -79,7 +79,7 @@ import { InMemoryCache } from "apollo-cache-inmemory";
   ],
   providers: [{
     provide: APOLLO_OPTIONS,
-    useFactory(httpLink: HttpLink) {
+    useFactory: (httpLink: HttpLink) => {
       return {
         cache: new InMemoryCache(),
         link: httpLink.create({


### PR DESCRIPTION
By switching over to an arrow function AOT compilation works properly. In addition, the documentation should show it this way since it's typically the way providers are listed.