### PR TITLE
docs: remove information about returnPartialData query option

### DIFF
--- a/docs/source/basics/queries.md
+++ b/docs/source/basics/queries.md
@@ -68,7 +68,7 @@ property that is an `Observable`.
 We can see that the result object contains `loading`, a Boolean indicating if
 the query is "in-flight." The observable will only emit once when the query is
 complete, and `loading` will be set to false unless you set the `watchQuery`
-parameters `notifyOnNetworkStatusChange` or `returnPartialData` to true. Once
+parameters `notifyOnNetworkStatusChange` to true. Once
 the query has completed, it will also contain a `data` object with
 `currentUser`, the field we've picked out in `CurrentUserForProfile`.
 


### PR DESCRIPTION
`returnPartialData` has been [removed in Apollo 1.0](https://gist.github.com/helfer/3bbd1a727e30bbad9d2873803855fb91#returnpartialdata). This change removes information about that parameter from Queries docs to avoid potential confusion.