### PR TITLE
Clarifications in boost-migration.md

### DIFF
--- a/docs/source/recipes/boost-migration.md
+++ b/docs/source/recipes/boost-migration.md
@@ -105,6 +105,25 @@ The `InMemoryCache` is our recommended cache implementation for Apollo Client. T
 
 If you are using configuration options on Apollo Angular Boost, your migration path will vary depending on which ones you use.
 
+Type your configuration options object as ApolloClientOptions so you can use IntelliSense features on your editor.
+```ts
+export function createApollo(httpLink: HttpLink) {
+  return {
+    cache: new InMemoryCache(),
+    link: ApolloLink.from([
+      onError(({ graphQLErrors, networkError }) => {
+        ...
+      }),
+      httpLink.create({
+        uri: aux.env.graphql
+      }),
+    ]),
+    resolvers,
+    typeDefs
+  } as ApolloClientOptions<any>;
+}
+```
+
 We will try to step by step eject each configuration.
 
 ### uri and HttpOptions
@@ -133,7 +152,17 @@ This one, you put to `HttpLink.create()`.
 
 ### clientState
 
-You can pass whole object to `apollo-link-state` by also including ApolloCache
+You can pass all the proprieties of the object to `apollo-link-state` by also including ApolloCache.
+```ts
+{
+    cache: new InMemoryCache(),
+    link: ApolloLink.from([
+      ...
+    ]),
+    resolvers,
+    typeDefs
+  }
+```
 
 ### onError
 


### PR DESCRIPTION
The explanation on how to migrate the `clientState` object was confusing. At first I thought I was meant to pass the object `apollo-link-state` as a propriety. Like:
```ts
{
  cache: new InMemoryCache(),
  link: ApolloLink.from([
      ...
  ]),
  clientState: {
    resolvers,
    typeDefs
  }
}
```
I rephrased it to make it more clear.

<!--
  Thanks for filing a pull request on Apollo Angular!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Angular is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Try to include the Pull Request inside of CHANGELOG.md
