### PR TITLE
chore(deps): remove @angular/http dependency

### DIFF
--- a/packages/apollo-angular-link-http-common/package.json
+++ b/packages/apollo-angular-link-http-common/package.json
@@ -36,7 +36,6 @@
     "@angular/compiler": "8.0.0",
     "@angular/compiler-cli": "8.0.0",
     "@angular/core": "8.0.0",
-    "@angular/http": "7.2.13",
     "@angular/platform-browser": "8.0.0",
     "@angular/platform-browser-dynamic": "8.0.0",
     "@angular/platform-server": "8.0.0",

--- a/packages/apollo-angular-link-http/package.json
+++ b/packages/apollo-angular-link-http/package.json
@@ -39,7 +39,6 @@
     "@angular/compiler": "8.0.0",
     "@angular/compiler-cli": "8.0.0",
     "@angular/core": "8.0.0",
-    "@angular/http": "7.2.13",
     "@angular/platform-browser": "8.0.0",
     "@angular/platform-browser-dynamic": "8.0.0",
     "@angular/platform-server": "8.0.0",


### PR DESCRIPTION
Since the http package is deprecated, there is no need to have it in dependencies, also it causes a warn when installing the package:

```
npm WARN apollo-angular-link-http@1.6.0 requires a peer of @angular/core@^6.0.0 || ^7.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN apollo-angular-link-http@1.6.0 requires a peer of @angular/common@^6.0.0 || ^7.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN apollo-angular-link-http-common@1.6.0 requires a peer of @angular/core@^6.0.0 || ^7.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN apollo-angular-link-http-common@1.6.0 requires a peer of @angular/common@^6.0.0 || ^7.0.0 but none is installed. You must install peer dependencies yourself.
```

Remove `@angular/http` dependency from `apollo-angular-link-http-common` and `apollo-angular-link-http`

Close #1208