### PR TITLE
Fix broken link in Getting Started docs

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -29,9 +29,7 @@ The docs are divided into three distinct sections to make it easy to find your w
 1. **Features**, which showcase some of the advanced capabilities of Apollo Client that your app may need.
 1. **Recipes**, to isolate and explain how to do common patterns.
 
-Getting started is as simple as installing a few libraries from [npm](https://npmjs.org)! The [setup][] is a good place to start your adventure with Apollo!
-
-[setup](https://www.apollographql.com/docs/angular/basics/setup/)
+Getting started is as simple as installing a few libraries from [npm](https://npmjs.org)! The [setup](https://www.apollographql.com/docs/angular/basics/setup/) is a good place to start your adventure with Apollo!
 
 ### Compatible tools
 


### PR DESCRIPTION
Fix broken Markdown link formatting in the Getting Started docs.