### PR TITLE
Fixed type definition for subscribe

### DIFF
--- a/packages/apollo-angular/CHANGELOG.md
+++ b/packages/apollo-angular/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNext
 
+- Fixed type definition for subscribe [PR #1290](https://github.com/apollographql/apollo-angular/pull/1290)
+
 ### v1.6.0
 
 - Angular 8 [PR #1206](https://github.com/apollographql/apollo-angular/pull/1206)

--- a/packages/apollo-angular/src/Apollo.ts
+++ b/packages/apollo-angular/src/Apollo.ts
@@ -49,7 +49,7 @@ export class ApolloBase<TCacheShape = any> {
   public subscribe<T, V = R>(
     options: SubscriptionOptions<V>,
     extra?: ExtraSubscriptionOptions,
-  ): Observable<any> {
+  ): Observable<FetchResult<T>> {
     const obs = from(fixObservable(this.client.subscribe<T, V>({...options})));
 
     return extra && extra.useZone !== true


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Angular!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Angular is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Try to include the Pull Request inside of CHANGELOG.md

According to apollo-client it returns a FetchResult<T> whereas apollo-angular says it's an any: https://github.com/apollographql/apollo-client/blob/7eaf4132cd2cd6244260777799406aaa03fcf377/packages/apollo-client/src/ApolloClient.ts#L355

