### PR TITLE
docs(authentication.md): apollo should be injected via constructor in AuthService

### DIFF
--- a/docs/source/recipes/authentication.md
+++ b/docs/source/recipes/authentication.md
@@ -129,8 +129,7 @@ const PROFILE_QUERY = gql`
 
 @Injectable()
 class AuthService {
-  apollo: Apollo;
-
+constructor(private apollo: Apollo) {}
   logout() {
     // some app logic
 


### PR DESCRIPTION
`apollo: Apollo` should be injected via constructor and not just a simple declaration

<!--
  Thanks for filing a pull request on Apollo Angular!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Angular is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

