### PR TITLE
Release v1.7.0

### DIFF
--- a/packages/apollo-angular-boost/CHANGELOG.md
+++ b/packages/apollo-angular-boost/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+### vNext
+
+### v1.6.0
+
+- Bump `apollo-angular-link-http` to `~1.8.0`
+- Bump `apollo-angular` to `1.7.0`
+
 ### v1.5.0
 
 - Support Angular 8

--- a/packages/apollo-angular-boost/package.json
+++ b/packages/apollo-angular-boost/package.json
@@ -6,7 +6,7 @@
   "main": "build/bundles/ngApolloBoost.umd.js",
   "module": "build/fesm5/ngApolloBoost.js",
   "typings": "build/ngApolloBoost.d.ts",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "repository": {
     "type": "git",
     "url": "apollographql/apollo-angular"
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "apollo-cache-inmemory": "~1.6.0",
-    "apollo-angular": "~1.6.0",
+    "apollo-angular": "~1.7.0",
     "apollo-client": "^2.6.0",
     "apollo-angular-link-http": "~1.8.0",
     "apollo-link": "~1.2.2",

--- a/packages/apollo-angular/CHANGELOG.md
+++ b/packages/apollo-angular/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ### vNext
 
+### v1.7.0
+
 - Fixed type definition for subscribe [PR #1290](https://github.com/apollographql/apollo-angular/pull/1290)
+- Fix global scope naming for UMD build [PR #1305](https://github.com/apollographql/apollo-angular/pull/1305)
+- Introduce useInitialLoading in watch [PR #1306](https://github.com/apollographql/apollo-angular/pull/1306)
 
 ### v1.6.0
 

--- a/packages/apollo-angular/package.json
+++ b/packages/apollo-angular/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-angular",
   "description": "Use your GraphQL data in your Angular app, with the Apollo Client",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "author": "Kamil Kisiela <kamil.kisiela@gmail.com> (http://github.com/kamilkisiela/)",
   "license": "MIT",
   "sideEffects": false,


### PR DESCRIPTION
- Fixed type definition for subscribe [PR #1290](https://github.com/apollographql/apollo-angular/pull/1290)
- Fix global scope naming for UMD build [PR #1305](https://github.com/apollographql/apollo-angular/pull/1305)
- Introduce useInitialLoading in watch [PR #1306](https://github.com/apollographql/apollo-angular/pull/1306)