### PR TITLE
Add token for named Apollo client.

### DIFF
--- a/packages/apollo-angular/testing/src/module.ts
+++ b/packages/apollo-angular/testing/src/module.ts
@@ -11,6 +11,10 @@ export const APOLLO_TESTING_CACHE = new InjectionToken<ApolloCache<any>>(
   'apollo-angular/testing cache',
 );
 
+export const APOLLO_TESTING_CLIENT_NAME = new InjectionToken<string>(
+  'apollo-angular/testing client name',
+);
+
 @NgModule({
   imports: [ApolloModule],
   providers: [
@@ -25,14 +29,28 @@ export class ApolloTestingModule {
     @Optional()
     @Inject(APOLLO_TESTING_CACHE)
     cache?: ApolloCache<any>,
+    @Optional()
+    @Inject(APOLLO_TESTING_CLIENT_NAME)
+    name?: string,
   ) {
-    apollo.create({
-      link: new ApolloLink(operation => backend.handle(operation)),
-      cache:
-        cache ||
-        new InMemoryCache({
-          addTypename: false,
-        }),
-    });
+    if (name) {
+      apollo.create({
+        link: new ApolloLink(operation => backend.handle(operation)),
+        cache:
+          cache ||
+          new InMemoryCache({
+            addTypename: false,
+          }),
+      }, name);
+    } else {
+      apollo.create({
+        link: new ApolloLink(operation => backend.handle(operation)),
+        cache:
+          cache ||
+          new InMemoryCache({
+            addTypename: false,
+          }),
+      });
+    }
   }
 }


### PR DESCRIPTION
I try create solution for https://spectrum.chat/apollo/angular-apollo/trying-to-test-a-service-with-a-non-default-endpoint~b4e338bf-78fa-4cf2-8470-d26f1122bee4 (and maybe apollographql#1029).
I'm not very good in Angular, but i need test named Apollo connection. There is idea how to use Apollo named client in ApolloTestingModule.
